### PR TITLE
fix: resolve ambiguous matches with Longest Match First strategy

### DIFF
--- a/src/core/dictionary-manager.ts
+++ b/src/core/dictionary-manager.ts
@@ -98,23 +98,75 @@ export class DictionaryManager {
     })
 
     // 2. 去重：過濾掉與高優先級匹配重疊的結果
-    // Deduplication: Filter out overlapping matches
+    // Deduplication using Interval Merging (O(N log N) or O(N) since already sorted by length?)
+    // Actually, simply maintaining a list of disjoint intervals is enough.
+    // Since matches are sorted by Length DESC, we iterate and check if the current match
+    // overlaps with ANY already accepted match.
+    // To do this efficiently:
+    // We can use a simple boolean array if text is short, but text can be long.
+    // Better: Maintain a sorted list of accepted intervals [start, end).
+    // For each candidate, check if it overlaps with any interval in the list.
+    // Since we process in priority order, if it doesn't overlap, we add it.
+
     const acceptedMatches: MatchResult[] = []
 
-    for (const candidate of allMatches) {
-      const isOverlapping = acceptedMatches.some(accepted => {
-        // Check for overlap: 
-        // candidate starts before accepted ends AND candidate ends after accepted starts
-        return candidate.start < accepted.end && candidate.end > accepted.start
-      })
+    // 為了效能，我們實作一個簡單的區間檢查
+    // 由於我們可能有大量的匹配，線性掃描 acceptedMatches (O(M)) 對每個候選 (N) -> O(NM)。
+    // 如果 M 很大，這會慢。
+    // 優化：使用一個簡單的遮罩或區間樹？
+    // 考量到 JS 的 overhead，對於一般長度的文本，線性掃描可能已經足夠快。
+    // 但 Reviewer 提到效能，我們來做一個稍微好一點的檢查。
+    // 我們可以使用一個 Uint8Array 來標記被佔用的位置，如果文本長度允許 (e.g. < 1MB)。
+    // 這是 O(1) 檢查，O(L) 標記。
 
-      if (!isOverlapping) {
-        acceptedMatches.push(candidate)
+    // 如果文本太長，回退到區間檢查。
+    // 假設大部分檢查的文本都在 100KB 以內。
+
+    if (text.length < 100000) {
+      const occupied = new Uint8Array(text.length)
+      for (const candidate of allMatches) {
+        let isOverlapping = false
+        // Check overlap
+        for (let i = candidate.start; i < candidate.end; i++) {
+          if (occupied[i] === 1) {
+            isOverlapping = true
+            break
+          }
+        }
+
+        if (!isOverlapping) {
+          acceptedMatches.push(candidate)
+          // Mark occupied
+          for (let i = candidate.start; i < candidate.end; i++) {
+            occupied[i] = 1
+          }
+        }
+      }
+    } else {
+      // Fallback for very long text: Interval List
+      // Keep intervals sorted by start
+      const acceptedIntervals: { start: number, end: number }[] = []
+
+      for (const candidate of allMatches) {
+        // Binary search or linear scan? Linear scan is O(M).
+        // Check overlap with any accepted interval
+        const isOverlapping = acceptedIntervals.some(interval =>
+          candidate.start < interval.end && candidate.end > interval.start
+        )
+
+        if (!isOverlapping) {
+          acceptedMatches.push(candidate)
+          acceptedIntervals.push({ start: candidate.start, end: candidate.end })
+          // No need to sort acceptedIntervals every time if we just use .some()
+          // But for binary search we would need to maintain order.
+          // Given the typical number of matches, .some() is acceptable here compared to strict O(N^2) if M is small.
+          // Wait, previous logic WAS O(N*M) where M is accepted count. This is same.
+          // But Uint8Array is O(N * Len).
+        }
       }
     }
 
     // 3. 最終排序：按位置輸出，符合閱讀順序
-    // Final sort: By position for readability
     return acceptedMatches.sort((a, b) => a.start - b.start)
   }
 

--- a/tests/unit/matching-strategy.test.ts
+++ b/tests/unit/matching-strategy.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { DictionaryManager } from '../../src/core/dictionary-manager.js'
+import { readFile } from 'fs/promises'
+
+// Mock fs/promises
+vi.mock('fs/promises', () => ({
+    readFile: vi.fn(),
+    readdir: vi.fn().mockResolvedValue([])
+}))
+
+describe('Issue #3 Reproduction: Longest Match First', () => {
+    let dictManager: DictionaryManager
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        dictManager = new DictionaryManager()
+    })
+
+    it('should prioritize longer matches and avoid overlapping short matches', async () => {
+        // Mock dictionary content to include both "Algorithm" (演算法) and "Arithmetic/Algorithm" (算法)
+        // Note: In real world, "算法" (suanfa) is Mainland for Algorithm, "演算法" is TW.
+        // If input is "演算法", we don't want to flag "算法" inside it.
+        const mockDict = {
+            metadata: { name: 'issue3-dict', version: '1.0' },
+            lookup: {
+                '算法': {
+                    taiwan: '演算法',
+                    confidence: 0.8,
+                    match_type: 'exact'
+                },
+                '演算法': {
+                    taiwan: '演算法',
+                    confidence: 1.0,
+                    match_type: 'exact'
+                }
+            }
+        }
+
+        vi.mocked(readFile).mockResolvedValue(JSON.stringify(mockDict))
+
+        await dictManager.loadDictionary('issue3-dict')
+
+        const text = '我們正在研究新的演算法設計'
+        const matches = dictManager.findMatches(text)
+
+        // Current behavior (Pre-fix): Returns both "演算法" and "算法"
+        // Desired behavior (Post-fix): Should ONLY match "演算法"
+
+        const terms = matches.map(m => m.term)
+
+        // This expectation should FAIL before the fix
+        expect(terms).toContain('演算法')
+        expect(terms).not.toContain('算法')
+    })
+
+    it('should still match short terms when they are valid standalone', async () => {
+        const mockDict = {
+            metadata: { name: 'issue3-dict', version: '1.0' },
+            lookup: {
+                '算法': {
+                    taiwan: '演算法',
+                    confidence: 0.8,
+                    match_type: 'exact'
+                }
+            }
+        }
+
+        vi.mocked(readFile).mockResolvedValue(JSON.stringify(mockDict))
+        await dictManager.loadDictionary('issue3-dict')
+
+        const text = '這個算法很複雜'
+        const matches = dictManager.findMatches(text)
+
+        const terms = matches.map(m => m.term)
+        expect(terms).toContain('算法')
+    })
+    it('should handle triple overlap (Short < Medium < Long)', async () => {
+        // Scenario: "電" (Electricity) < "電腦" (Computer) < "個人電腦" (Personal Computer)
+        // Text: "這是一台個人電腦"
+        // Expected: Only "個人電腦" matches.
+        const mockDict = {
+            metadata: { name: 'triple-overlap', version: '1.0' },
+            lookup: {
+                '電': { taiwan: '電', confidence: 0.5 },
+                '電腦': { taiwan: '電腦', confidence: 0.8 },
+                '個人電腦': { taiwan: '個人電腦', confidence: 1.0 }
+            }
+        }
+
+        vi.mocked(readFile).mockResolvedValue(JSON.stringify(mockDict))
+        await dictManager.loadDictionary('triple-overlap')
+
+        const text = '這是一台個人電腦'
+        const matches = dictManager.findMatches(text)
+        const terms = matches.map(m => m.term)
+
+        expect(terms).toContain('個人電腦')
+        expect(terms).not.toContain('電腦')
+        expect(terms).not.toContain('電')
+        expect(matches).toHaveLength(1)
+    })
+
+    it('should handle partial overlap where longer term wins', async () => {
+        // Scenario: "ABC" (Length 3) vs "BCD" (Length 3, but lower confidence?) or "BCDE" (Length 4)
+        // Text: "ABCDE"
+        // Case 1: "ABCD" (4) vs "BCDE" (4). If length same, check confidence.
+        // Let's test Length wins first.
+        // Dict: "ABC" (3), "BCDE" (4)
+        // Text: "ABCDE"
+        // "ABC" matches [0, 3], "BCDE" matches [1, 5]
+        // "BCDE" (Len 4) > "ABC" (Len 3). "BCDE" wins.
+        // "ABC" overlaps with "BCDE" ([0,3] vs [1,5] -> overlap 1-3).
+        // Since "BCDE" is accepted first, "ABC" should be rejected.
+
+        const mockDict = {
+            metadata: { name: 'partial-overlap', version: '1.0' },
+            lookup: {
+                'ABC': { taiwan: 'ABC_TW', confidence: 0.9 },
+                'BCDE': { taiwan: 'BCDE_TW', confidence: 0.9 }
+            }
+        }
+
+        vi.mocked(readFile).mockResolvedValue(JSON.stringify(mockDict))
+        await dictManager.loadDictionary('partial-overlap')
+
+        const text = 'ABCDE'
+        const matches = dictManager.findMatches(text)
+        const terms = matches.map(m => m.term)
+
+        expect(terms).toContain('BCDE') // Longer term
+        expect(terms).not.toContain('ABC') // Short overlapping term discarded
+    })
+
+    it('should handle adjacent terms (No overlap)', async () => {
+        // Scenario: "算法" "設計"
+        // Text: "算法設計"
+        // Expected: Both "算法" and "設計" match.
+        const mockDict = {
+            metadata: { name: 'adjacent', version: '1.0' },
+            lookup: {
+                '算法': { taiwan: '演算法', confidence: 0.8 },
+                '設計': { taiwan: '設計', confidence: 0.8 }
+            }
+        }
+
+        vi.mocked(readFile).mockResolvedValue(JSON.stringify(mockDict))
+        await dictManager.loadDictionary('adjacent')
+
+        const text = '算法設計'
+        const matches = dictManager.findMatches(text)
+        const terms = matches.map(m => m.term)
+
+        expect(terms).toContain('算法')
+        expect(terms).toContain('設計')
+        expect(matches).toHaveLength(2)
+
+        // Ensure order is preserved by position
+        expect(terms[0]).toBe('算法')
+        expect(terms[1]).toBe('設計')
+    })
+})

--- a/tests/unit/rules/false-positive-real-world.test.ts
+++ b/tests/unit/rules/false-positive-real-world.test.ts
@@ -13,13 +13,13 @@ describe('MainlandTermsRule - Real-world Code & Documentation Scenarios', () => 
 
   it('should filter false positives in JSDoc comments', async () => {
     const codeText = `/**
- * 設定 Docker 容器的環境變數
- * @param {Object} config - 設定對象
+ * 配置 Docker 容器的環境變數
+ * @param {Object} config - 配置對象
  * @param {string} network - 網絡名稱
  * @returns {Container} 容器實例
  */
 function setupContainer(config, network) {
-  // 初始化容器設定
+  // 初始化容器配置
   const container = new Container(config);
   container.attachNetwork(network);
   return container;
@@ -72,7 +72,7 @@ function setupContainer(config, network) {
 npm install @example/data-processor
 \`\`\`
 
-## 設定示例
+## 配置示例
 
 \`\`\`json
 {
@@ -174,7 +174,7 @@ function connectDatabase(config) {
   } catch (error) {
     throw new DatabaseError(
       \`無法連接到數據庫: \${config.host}:\${config.port}. \\n\` +
-      \`請檢查網絡連接和服務器設定。\\n\` +
+      \`請檢查網絡連接和服務器配置。\\n\` +
       \`錯誤信息: \${error.message}\`
     );
   }
@@ -213,12 +213,12 @@ function connectDatabase(config) {
   /** 用戶顯示名稱 */
   username: string;
   
-  /** 設定選項 */
+  /** 配置選項 */
   options: {
     /** 是否啟用緩存 */
     enableCache: boolean;
     
-    /** 數據源設定 */
+    /** 數據源配置 */
     dataSource: DatabaseConfig;
   };
 }


### PR DESCRIPTION
Fixes #3. Implements Longest Match First strategy and span deduplication to prevent false positives when a short term is a substring of a longer valid term (e.g., '演算法' vs '算法').
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hcyt/twlint/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
