### PR TITLE
feat(dict): add 'robustness' to software-development

### DIFF
--- a/dictionaries-csv/domains/software-development.csv
+++ b/dictionaries-csv/domains/software-development.csv
@@ -66,6 +66,7 @@ continuous-delivery,持續交付,持续交付,持續交付,CD,0.90,mainland-term
 repository,版本庫,仓库,倉庫,repository,0.90,mainland-term,台灣版本控制標準,tech,exact,,,,true
 merge,合併,合并,合併,merge,0.85,mainland-term,台灣版本控制標準,tech,exact,,,,true
 pull-request,拉取請求,拉取请求,拉取請求,pull request,0.90,mainland-term,台灣協作開發標準,tech,exact,,,,true
+robustness,穩健性,鲁棒性,魯棒性,robustness,0.95,mainland-term,台灣標準意譯,tech,exact,,,,true
 rollback,回溯,回滚,回滾,rollback,0.90,mainland-term,台灣版本控制標準,tech,exact,,,,true
 unit-test,單元測試,单元测试,單元測試,unit test,0.90,mainland-term,台灣測試標準,tech,exact,,,,true
 integration-test,整合測試,集成测试,集成測試,integration test,0.90,mainland-term,台灣測試標準,tech,exact,,,,true

--- a/src/dictionaries/index.json
+++ b/src/dictionaries/index.json
@@ -68,7 +68,7 @@
       "description": "軟體開發",
       "type": "domain",
       "required": false,
-      "entries": 117
+      "entries": 118
     },
     {
       "name": "user-interface",
@@ -79,5 +79,5 @@
     }
   ],
   "version": "1.0.0",
-  "buildTime": "2025-10-19T10:23:42.699Z"
+  "buildTime": "2026-02-19T06:23:19.171Z"
 }

--- a/src/dictionaries/software-development.json
+++ b/src/dictionaries/software-development.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "software-development",
     "version": "1.0.0",
-    "entries": 117
+    "entries": 118
   },
   "lookup": {
     "算法": {
@@ -1906,6 +1906,38 @@
       "confidence": 0.9,
       "category": "mainland-term",
       "reason": "台灣協作開發標準",
+      "match_type": "exact",
+      "autofix_safe": true
+    },
+    "鲁棒性": {
+      "taiwan": "穩健性",
+      "confidence": 0.95,
+      "category": "mainland-term",
+      "reason": "台灣標準意譯",
+      "match_type": "exact",
+      "autofix_safe": true
+    },
+    "鲁棒性_robustness": {
+      "taiwan": "穩健性",
+      "confidence": 0.95,
+      "category": "mainland-term",
+      "reason": "台灣標準意譯",
+      "match_type": "exact",
+      "autofix_safe": true
+    },
+    "魯棒性": {
+      "taiwan": "穩健性",
+      "confidence": 0.95,
+      "category": "mainland-term",
+      "reason": "台灣標準意譯",
+      "match_type": "exact",
+      "autofix_safe": true
+    },
+    "魯棒性_robustness": {
+      "taiwan": "穩健性",
+      "confidence": 0.95,
+      "category": "mainland-term",
+      "reason": "台灣標準意譯",
       "match_type": "exact",
       "autofix_safe": true
     },


### PR DESCRIPTION
Adds 'robustness' -> '穩健性/魯棒性' mapping to the software development dictionary.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hcyt/twlint/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
